### PR TITLE
Notify Invalid Row

### DIFF
--- a/labbu.py
+++ b/labbu.py
@@ -108,15 +108,20 @@ class labbu:
 		p = Path(fpath)
 		self.lab_name = p.stem
 		self.lab = []
+		index = 0
 		try:
 			with open(fpath, 'r', encoding='utf-8') as f:
 				for line in f:
+					index += 1
 					line = fxy(line)
 					split_line = line.rstrip().split(' ')
 					self.lab.append({'phone': split_line[2],'start': split_line[0],'end': split_line[1]})
 				f.close()
 		except:
-			print(f"Unable to open lab {self.lab_name}")
+			if(index > 0):
+				print(f"Invalid line : {index}")
+			else:
+				print(f"Unable to open lab {self.lab_name}")
 			print('skipping')
 		return self.lab
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,4 @@
 mytextgrid
+click
+PyYAML
+ftfy


### PR DESCRIPTION
Displays the number of invalid rows if a particular row cannot be read by the load_lab function.

Example:
![image](https://github.com/spicytigermeat/labbu/assets/93469977/4cb2d52b-dab9-43f1-b04c-b029b90e021f)



